### PR TITLE
Support various generic objects as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+Next Release
+------------
+* add input support for array-like objects, other objects via toString(), and decimal numbers stored as a string, #2
+
 0.2.1 / 2014-04-13
 ------------------
 * add base64 output, #5
-* npmignore the references, #4 
+* npmignore the references, #4
 
 
 0.2.0 / 2014-01-15

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This library exposes a single function that takes a data parameter and an option
 * `bytes`: Byte array; an array of numbers, each representing one byte of data
 * `buffer`: A Node.js native Buffer object
 
-The default encoding for `options.out` is a buffer (`buffer`). The input format is duck-typed if it's an Array (`bytes`) or Buffer (`buffer`) or Number object. If it's a string, it's interpreted as `binary` unless it's prefixed by `0x` (then it's `hex`). If `options.in` is set, it overrides the automatic duck-typing of the input variable.
+The default encoding for `options.out` is a buffer (`buffer`). The input format is duck-typed if it's an Array (`bytes`), or Array-like (has a `length` property and can be accessed by index; `bytes`), or Buffer (`buffer`) or Number object. If it's a string, it's interpreted as `binary` unless it's prefixed by `0x` (then it's `hex`), or it's just digits (decimal number stored as a string). If it's any other type of object, it's coerced into a string (using its `toString()` method) and proccessed as a string. If `options.in` is set, it overrides the automatic duck-typing of the input variable.
 
 ```js
 var conv = require('binstring');

--- a/lib/binstring.js
+++ b/lib/binstring.js
@@ -11,6 +11,21 @@ function bufferToBytes(data) {
 var binString = module.exports = function binString(data, options) {
   // Set default options
   options = options || {};
+
+  function duckString(str) {
+    if (str.substring(0,2) == '0x') {
+      return new Buffer(str.slice(2), 'hex');
+    } else if (parseInt(str)+'' == str) {
+      // Integer stored as a string
+      var hex = parseInt(str).toString(16);
+      if (hex.length % 2 !== 0) hex = '0'+hex;
+      return new Buffer(hex, 'hex');
+    } else {
+      // Binary string
+      return new Buffer(str, 'binary');
+    }
+  }
+
   if (Array.isArray(data)) {
     data = new Buffer(data);
   } else if (typeof data == 'number') {
@@ -18,18 +33,22 @@ var binString = module.exports = function binString(data, options) {
   } else if (typeof data == 'string') {
     if (!options.in) {
       // Quack, quack! Duck-type the input
-      if (data.slice(0,2) == '0x') {
-        data = new Buffer(data.slice(2), 'hex');
-      } else {
-        // Binary string
-        data = new Buffer(data, 'binary');
-      }
+      data = duckString(data);
     } else {
       data = new Buffer(data, options.in);
     }
+  } else if (typeof data == 'object' && !Buffer.isBuffer(data)) {
+    // Some object that's not a Buffer...
+    if (typeof data.length !== 'undefined' && data.length > 0 && typeof data[0] !== 'undefined') {
+      // "Array-like"
+      data = new Buffer(Array.apply([], data));
+    } else {
+      // Some other object type; use its toString() method
+      data = duckString(data.toString());
+    }
   }
   if (!options.out) options.out = 'buffer';
-  
+
   // Convert
   switch (options.out) {
     case 'buffer':

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "url": "https://github.com/cryptocoinjs/binstring",
     "type": "git"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "main": "./lib/binstring.js"
 }

--- a/test/binstring.test.js
+++ b/test/binstring.test.js
@@ -13,13 +13,34 @@ describe('+ convert(data)', function() {
     T (Buffer.isBuffer(test));
     EQ (test.toString('hex'), '68656c6c6f' );
   }),
+  it('should duck-type an array-like object', function() {
+    var test = conv(new Uint8Array([104,101,108,108,111]));
+    T (Buffer.isBuffer(test));
+    EQ (test.toString('hex'), '68656c6c6f' );
+  }),
   it('should duck-type a Buffer', function() {
     var test = conv(new Buffer([104,101,108,108,111]));
     T (Buffer.isBuffer(test));
     EQ (test.toString('hex'), '68656c6c6f' );
   }),
+  it('should duck-type an object using toString()', function() {
+    var input = {
+      a: 10,
+      toString: function() {
+        return this.a+5+'';
+      }
+    };
+    var test = conv(input);
+    T (Buffer.isBuffer(test));
+    EQ (test.toString('hex'), '0f' );
+  }),
   it('should duck-type a Number', function() {
     var test = conv(48879);
+    T (Buffer.isBuffer(test));
+    EQ (test.toString('hex'), 'beef' );
+  }),
+  it('should duck-type a number stored as a string', function() {
+    var test = conv('48879');
     T (Buffer.isBuffer(test));
     EQ (test.toString('hex'), 'beef' );
   }),
@@ -33,7 +54,7 @@ describe('+ convert(data)', function() {
     T (Buffer.isBuffer(test));
     EQ (test.toString('hex'), '307836383635366336633666' );
   }),
-  
+
   it('> should properly convert byte array...', function() {
     var input = [104,101,108,108,111];
     it('...to hex', function() {
@@ -48,7 +69,7 @@ describe('+ convert(data)', function() {
       EQ (test.toString('binary'), 'hello');
     })
   }),
-  
+
   it('> should properly convert hex string...', function() {
     var input = '68656c6c6f';
     it('...to binary', function() {
@@ -65,7 +86,7 @@ describe('+ convert(data)', function() {
       EQ (test.toString('binary'), 'hello');
     })
   }),
-  
+
   it('> should properly convert binary string...', function() {
     var input = 'hello';
     it('...to hex', function() {
@@ -82,7 +103,7 @@ describe('+ convert(data)', function() {
       EQ (test.toString('binary'), 'hello');
     })
   }),
-  
+
   it('> should properly convert utf8 string...', function() {
     var input = 'R\u00e9sum\u00e9';
     it('...to hex', function() {
@@ -102,7 +123,7 @@ describe('+ convert(data)', function() {
       EQ (test.toString('hex'), '52c3a973756dc3a9');
     })
   }),
-  
+
   it('> should properly convert Buffer...', function() {
     var input = new Buffer([104,101,108,108,111]);
     it('...to hex', function() {
@@ -118,4 +139,3 @@ describe('+ convert(data)', function() {
     })
   })
 })
-


### PR DESCRIPTION
Support array-like input objects, other objects via toString(), and decimal numbers stored as strings. Resolves #2 
